### PR TITLE
Fix bug in extension checking

### DIFF
--- a/helper_funcs.inc.php
+++ b/helper_funcs.inc.php
@@ -55,6 +55,7 @@ function pwg_privacy_serve_file ($path) {
 	global $conf;
 
 	$ext = get_extension($path);
+	$ext = strtolower($ext);
 
 	if (!in_array($ext, $conf['file_ext'])) {
 		pwg_privacy_reject_access('File extension is not allowed');
@@ -62,7 +63,6 @@ function pwg_privacy_serve_file ($path) {
 
 	$range_support = false;
 
-	$ext = strtolower($ext);
 	switch ($ext) {
 		case 'jpe': case 'jpeg': case 'jpg':
 			$mime='image/jpeg';

--- a/main.inc.php
+++ b/main.inc.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Version: 0.1.3
+Version: 0.1.3_dev
 Plugin Name: piwigo_privacy
 Plugin URI: http://piwigo.org/ext/extension_view.php?eid=849
 Author: Yoni Jah


### PR DESCRIPTION
Extension check was not case insensitive.
This implementation fixes bug explained in issue #11 

`_dev` added to version name in order to make sure it is clear this is not an official release.