### PR TITLE
added support for m4a mp4 audio only files

### DIFF
--- a/helper_funcs.inc.php
+++ b/helper_funcs.inc.php
@@ -76,6 +76,10 @@ function pwg_privacy_serve_file ($path) {
 			$mime="video/$ext";
 			$range_support=true;
 			break;
+		case 'm4a':
+		    $mime="audio/mp4";
+		    $range_support=true;
+		    break;
 		default: $mime='application/octet-stream';
 	}
 


### PR DESCRIPTION
This is the most elegant way I found of making the plugin work when serving a piwigo server from a subfolder of a domain.